### PR TITLE
Remove unused JWT imports

### DIFF
--- a/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/exceptions/GlobalExceptionHandler.java
+++ b/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/exceptions/GlobalExceptionHandler.java
@@ -1,9 +1,5 @@
 package com.repinsky.task_tracker_backend.exceptions;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;


### PR DESCRIPTION
## Summary
- clean up `GlobalExceptionHandler` imports

## Testing
- `./gradlew test` *(fails: unable to download gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685263f404148328a480c7c444b07cd4