### PR TITLE
Remove token value from logs

### DIFF
--- a/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/jwt/AuthTokenFilter.java
+++ b/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/jwt/AuthTokenFilter.java
@@ -34,7 +34,7 @@ public class AuthTokenFilter extends OncePerRequestFilter {
         try {
             String token = getTokenFromJwt(request);
             if (token != null) {
-                log.debug("Token found: " + token);
+                log.debug("Token found");
                 String validationError = jwtTokenUtil.validateJwtToken(token);
                 if (validationError.equals("")) {
                     String userData = jwtTokenUtil.getUserDataFromToken(token);


### PR DESCRIPTION
## Summary
- stop printing full JWT value in `AuthTokenFilter`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685263f5baf88328b2fc8187805fef75