### PR TITLE
Fix createdAt handling

### DIFF
--- a/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/models/Task.java
+++ b/task-tracker-backend/src/main/java/com/repinsky/task_tracker_backend/models/Task.java
@@ -3,8 +3,6 @@ package com.repinsky.task_tracker_backend.models;
 import com.repinsky.task_tracker_backend.constants.TaskStatus;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.Generated;
-import org.hibernate.annotations.GenerationTime;
 
 import java.sql.Timestamp;
 
@@ -40,7 +38,5 @@ public class Task {
     @Column(name = "completed_at")
     private Timestamp completedAt;
 
-    @PrePersist protected void onCreate() {
-        createdAt = new Timestamp(System.currentTimeMillis());
-    }
+    // Timestamp is set by the database default
 }

--- a/task-tracker-scheduler/src/main/java/com/repinsky/task_tracker_scheduler/models/Task.java
+++ b/task-tracker-scheduler/src/main/java/com/repinsky/task_tracker_scheduler/models/Task.java
@@ -38,7 +38,5 @@ public class Task {
     @Column(name = "completed_at")
     private Timestamp completedAt;
 
-    @PrePersist protected void onCreate() {
-        createdAt = new Timestamp(System.currentTimeMillis());
-    }
+    // Timestamp is set by the database default
 }


### PR DESCRIPTION
## Summary
- remove `onCreate` hooks from Task entities
- rely on database defaults for `created_at`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68526400c11883289c0b3367f476d34c