### PR TITLE
Fix duplicate kafka dependency

### DIFF
--- a/task-tracker-backend/build.gradle
+++ b/task-tracker-backend/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     implementation group: 'com.auth0', name: 'java-jwt', version: '4.4.0'
     implementation group: 'commons-validator', name: 'commons-validator', version: '1.8.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }


### PR DESCRIPTION
## Summary
- remove the second `spring-kafka` dependency from `task-tracker-backend/build.gradle`
